### PR TITLE
deps: Updated minimatch to prevent security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,107 @@
+{
+  "name": "karma-generic-preprocessor",
+  "version": "1.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async-reduce": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/async-reduce/-/async-reduce-0.0.1.tgz",
+      "integrity": "sha1-sja183bW+uOBze2QBqp/LHOxfzE="
+    },
+    "async.eachofseries": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.eachofseries/-/async.eachofseries-0.5.2.tgz",
+      "integrity": "sha1-naNK7/DTmV+UdQv5iv51OhEiAw0=",
+      "requires": {
+        "async.util.keyiterator": "0.5.2",
+        "async.util.noop": "0.5.2",
+        "async.util.once": "0.5.2",
+        "async.util.onlyonce": "0.5.2",
+        "async.util.setimmediate": "0.5.2"
+      }
+    },
+    "async.reduce": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.reduce/-/async.reduce-0.5.2.tgz",
+      "integrity": "sha1-sU3YD8NtCBhW5Wab5995PvlUOR4=",
+      "requires": {
+        "async.eachofseries": "0.5.2"
+      }
+    },
+    "async.util.isarray": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.isarray/-/async.util.isarray-0.5.2.tgz",
+      "integrity": "sha1-5i2sjyY29lh13PdSHC0k0N+yu98="
+    },
+    "async.util.isarraylike": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.isarraylike/-/async.util.isarraylike-0.5.2.tgz",
+      "integrity": "sha1-jn+H2pFB8vCZboBAR30NTv4/UPg=",
+      "requires": {
+        "async.util.isarray": "0.5.2"
+      }
+    },
+    "async.util.keyiterator": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.keyiterator/-/async.util.keyiterator-0.5.2.tgz",
+      "integrity": "sha1-M55s6PidAAQz+3gU4ico8/F1CQ0=",
+      "requires": {
+        "async.util.isarraylike": "0.5.2",
+        "async.util.keys": "0.5.2"
+      }
+    },
+    "async.util.keys": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.keys/-/async.util.keys-0.5.2.tgz",
+      "integrity": "sha1-XDTd2KPtt6eIPJtf4hJngbIJivY="
+    },
+    "async.util.noop": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.noop/-/async.util.noop-0.5.2.tgz",
+      "integrity": "sha1-vdYrl8sKo/YLWGrRSEaGmJdeWLk="
+    },
+    "async.util.once": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.once/-/async.util.once-0.5.2.tgz",
+      "integrity": "sha1-FFPLdATK0IImlPq6vEepblyqchY="
+    },
+    "async.util.onlyonce": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.onlyonce/-/async.util.onlyonce-0.5.2.tgz",
+      "integrity": "sha1-uOb8AErckjFk154y8oE+5GXCT/I="
+    },
+    "async.util.setimmediate": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.setimmediate/-/async.util.setimmediate-0.5.2.tgz",
+      "integrity": "sha1-KBLrq/KlgCd1jUvHeT0cz68QJV8="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-generic-preprocessor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Provides a way to define preprocessors inline in the karma configuration files.",
   "main": "index.js",
   "repository": {
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "async-reduce": "0.0.1",
-    "minimatch": "^1.0.0"
+    "async.reduce": "^0.5.2",
+    "minimatch": "^3.0.4"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
```
found 1 high severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details
```

For your usage, nothing has changed afaik. 

And there are some other minor changes to keep modern with `npm`